### PR TITLE
Join Dep Resolver and BUILD file modifier

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,7 @@ python_library(
     name = "pyllemi_lib",
     srcs = glob(
         ["*.py"],
-        exclude = ["*_test.py", "*main.py"],
+        exclude = ["*_test.py", "main.py"],
     ),
     deps = [
         "//adapters",

--- a/BUILD
+++ b/BUILD
@@ -2,13 +2,15 @@ python_library(
     name = "pyllemi_lib",
     srcs = glob(
         ["*.py"],
-        exclude = ["_test.py"],
+        exclude = ["*_test.py", "*main.py"],
     ),
     deps = [
         "//adapters",
         "//common/logger",
+        "//domain/build_pkgs",
         "//domain/imports",
         "//domain/targets",
+        "//domain/targets/plz",
     ],
 )
 

--- a/adapters/custom_arg_types.py
+++ b/adapters/custom_arg_types.py
@@ -14,7 +14,7 @@ def existing_file_arg_type(path: str) -> str:
 
 def existing_dir_arg_type(path: str) -> str:
     if os.path.isdir(path):
-        return path
+        return path.removeprefix(f".{os.path.sep}").removesuffix(os.path.sep)
 
     if os.path.isfile(path):
         raise argparse.ArgumentTypeError(f"expected {path} to be a dir, but is a file instead")

--- a/adapters/custom_arg_types.py
+++ b/adapters/custom_arg_types.py
@@ -10,3 +10,13 @@ def existing_file_arg_type(path: str) -> str:
         raise argparse.ArgumentTypeError(f"expected {path} to be a file, but is a dir instead")
 
     raise argparse.ArgumentTypeError(f"could not find {path}")
+
+
+def existing_dir_arg_type(path: str) -> str:
+    if os.path.isdir(path):
+        return path
+
+    if os.path.isfile(path):
+        raise argparse.ArgumentTypeError(f"expected {path} to be a dir, but is a file instead")
+
+    raise argparse.ArgumentTypeError(f"could not find {path}")

--- a/adapters/custom_arg_types_test.py
+++ b/adapters/custom_arg_types_test.py
@@ -3,7 +3,7 @@ import os
 import uuid
 from unittest import TestCase
 
-from adapters.custom_arg_types import existing_file_arg_type
+from adapters.custom_arg_types import existing_file_arg_type, existing_dir_arg_type
 
 
 class TestExistingFileArgType(TestCase):
@@ -46,5 +46,50 @@ class TestExistingFileArgType(TestCase):
             f"could not find {non_existent_path}",
             existing_file_arg_type,
             non_existent_path,
+        )
+        return
+
+
+class TestExistingDirArgType(TestCase):
+    def setUp(self) -> None:
+        self.test_dir_path = os.path.abspath(f"test_dir_{uuid.uuid4()}")
+        if os.path.exists(self.test_dir_path):
+            raise FileExistsError(f"Cannot create dir because path already exists: {self.test_dir_path}")
+        os.makedirs(self.test_dir_path)
+
+        with open(os.path.join(self.test_dir_path, "module.py"), "w") as f:
+            f.write(f"# TEST {self.__class__.__name__}")
+            f.write("import numpy")
+        return
+
+    def tearDown(self) -> None:
+        # Delete test files and dir.
+        for file in os.listdir(self.test_dir_path):
+            os.unlink(os.path.join(self.test_dir_path, file))
+        os.rmdir(self.test_dir_path)
+        return
+
+    def test_with_dir(self):
+        test_path = self.test_dir_path
+        self.assertEqual(test_path, existing_dir_arg_type(test_path))
+        return
+
+    def test_with_file(self):
+        test_path = os.path.join(self.test_dir_path, "module.py")
+        self.assertRaisesRegex(
+            argparse.ArgumentTypeError,
+            f"expected {test_path} to be a dir, but is a file instead",
+            existing_dir_arg_type,
+            test_path,
+        )
+        return
+
+    def test_with_invalid_path(self):
+        test_path = "potato"
+        self.assertRaisesRegex(
+            argparse.ArgumentTypeError,
+            f"could not find {test_path}",
+            existing_dir_arg_type,
+            test_path,
         )
         return

--- a/adapters/plz_query.py
+++ b/adapters/plz_query.py
@@ -84,17 +84,17 @@ def get_plz_build_graph(
     return json.loads("".join(stdout))
 
 
-def get_whatinputs(glob_paths: list[str]) -> WhatInputsResult:
+def get_whatinputs(paths: list[str]) -> WhatInputsResult:
     """
 
-    :param glob_paths: a Collection of paths to python modules.
+    :param paths: a Collection of OS paths to python modules.
     :return: a list of plz targets
     """
 
-    if len(glob_paths) == 0:
+    if len(paths) == 0:
         return WhatInputsResult(set(), set())
 
-    cmd = ["plz", "query", "whatinputs", *glob_paths]
+    cmd = ["plz", "query", "whatinputs", *paths]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     if not _is_success_return_code(proc.returncode):
         LOGGER.error(

--- a/common/logger/logger.py
+++ b/common/logger/logger.py
@@ -3,6 +3,7 @@ Utility function for setting up a logger that uses the logging function with a s
 """
 
 import logging  # noqa: LOG001
+import os
 import sys
 from logging.handlers import RotatingFileHandler
 from typing import Optional
@@ -26,7 +27,7 @@ class UpperThresholdFilter(logging.Filter):
 
 def setup_logger(
     name: str,
-    level: int,
+    level: Optional[int] = None,
     formatter: Optional[logging.Formatter] = None,
     filepath: Optional[str] = None,
 ) -> logging.Logger:
@@ -39,6 +40,8 @@ def setup_logger(
     :return: Logger instance
     """
 
+    level_from_env = os.getenv("PYLLEMI_LOG_LEVEL") or logging.WARNING
+
     log_fmt = (
         "%(asctime)s [%(levelname)s] [%(threadName)s] || %(funcName)s in %(pathname)s :%(lineno)d\n"
         "%(message)s\n"
@@ -49,7 +52,7 @@ def setup_logger(
         formatter = PrettyFormatter(log_fmt)
 
     logger = logging.getLogger(name)
-    logger.setLevel(level)
+    logger.setLevel(int(level_from_env))
 
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)

--- a/domain/build_files/build_file.py
+++ b/domain/build_files/build_file.py
@@ -72,6 +72,9 @@ class BUILDFile:
     def has_modifiable_nodes(self) -> bool:
         return len(self._modifiable_nodes) > 0
 
+    def __str__(self) -> str:
+        return self.dump_ast()
+
 
 def _update_ast_call_keywords(
     node: ast.Call,

--- a/domain/build_files/build_file.py
+++ b/domain/build_files/build_file.py
@@ -57,7 +57,6 @@ class BUILDFile:
                 ast_call,
                 {
                     "deps": domain_python_target.kwargs["deps"],
-                    "srcs": domain_python_target.kwargs["srcs"],
                 },
             )
         return

--- a/domain/build_pkgs/BUILD
+++ b/domain/build_pkgs/BUILD
@@ -4,7 +4,7 @@ python_library(
     name = "build_pkgs",
     srcs = glob(
         ["*.py"],
-        exclude = ["_test.py"],
+        exclude = ["*_test.py"],
     ),
     deps = [
         "//common/logger",

--- a/domain/imports/enriched_import.py
+++ b/domain/imports/enriched_import.py
@@ -1,7 +1,12 @@
 import os
 from dataclasses import dataclass
 from enum import IntEnum, unique
+from glob import glob
 from typing import Optional
+
+from common.logger.logger import setup_logger
+
+LOGGER = setup_logger(__name__)
 
 
 @unique
@@ -68,9 +73,13 @@ def to_whatinputs_input(import_: EnrichedImport) -> Optional[list[str]]:
         return [os_path_from_reporoot + ".pyi"]
 
     if import_.type_ == ImportType.PACKAGE:
-        return [
-            os.path.join(os_path_from_reporoot, "**", "*.py"),
-            os.path.join(os_path_from_reporoot, "**", "*.pyi"),
+        all_paths: list[str] = [
+            *glob(os.path.join(os_path_from_reporoot, "**", "*.py"), recursive=True),
+            *glob(os.path.join(os_path_from_reporoot, "**", "*.pyi"), recursive=True),
         ]
 
+        if not all_paths:
+            LOGGER.warning(f"Could not find any importable modules in package '{import_.import_}'.")
+            return None
+        return all_paths
     return None

--- a/domain/imports/enriched_import_test.py
+++ b/domain/imports/enriched_import_test.py
@@ -1,5 +1,4 @@
 import os
-from unittest import TestCase
 
 from domain.imports.enriched_import import EnrichedImport, ImportType, resolve_import_type, to_whatinputs_input
 from utils.mock_python_library_test_case import MockPythonLibraryTestCase
@@ -30,7 +29,7 @@ class TestResolveImportType(MockPythonLibraryTestCase):
         return
 
 
-class TestToWhatInputsInput(TestCase):
+class TestToWhatInputsInput(MockPythonLibraryTestCase):
     def test_module(self):
         import_ = EnrichedImport("test.module", ImportType.MODULE)
         self.assertEqual(
@@ -40,9 +39,9 @@ class TestToWhatInputsInput(TestCase):
         return
 
     def test_package(self):
-        import_ = EnrichedImport("test.package", ImportType.PACKAGE)
+        import_ = EnrichedImport(self.subpackage_dir, ImportType.PACKAGE)
         self.assertEqual(
-            [os.path.join("test", "package", "**", "*.py"), os.path.join("test", "package", "**", "*.pyi")],
+            [self.subpackage_module],
             to_whatinputs_input(import_),
         )
         return

--- a/domain/imports/nodes_collator.py
+++ b/domain/imports/nodes_collator.py
@@ -28,6 +28,9 @@ class NodesCollator:
                 self._logger.debug(path)
             self._logger.debug(code)
             raise e
+        except FileNotFoundError as e:
+            self._logger.fatal(f"Could not read src at {path}", exc_info=e)
+            raise e
 
         for node in ast.walk(root):
             if isinstance(node, ast.Import) or isinstance(node, ast.ImportFrom):

--- a/domain/targets/plz/BUILD
+++ b/domain/targets/plz/BUILD
@@ -4,7 +4,7 @@ python_library(
     name = "plz",
     srcs = glob(
         ["*.py"],
-        exclude = ["_test.py"],
+        exclude = ["*_test.py"],
     ),
     deps = [
         "//adapters",

--- a/domain/targets/plz/BUILD
+++ b/domain/targets/plz/BUILD
@@ -10,7 +10,8 @@ python_library(
         "//adapters",
         "//common/logger",
         "//converters",
-        "//domain/ast",
+        "//domain/imports",
+        "//domain/targets",
     ],
 )
 

--- a/domain/targets/plz/dependency_resolver_test.py
+++ b/domain/targets/plz/dependency_resolver_test.py
@@ -8,7 +8,7 @@ from domain.targets.plz.dependency_resolver import DependencyResolver
 from domain.targets.plz_target import PlzTarget
 
 
-class MyTestCase(TestCase):
+class TestDependencyResolver(TestCase):
     def setUp(self) -> None:
         self.mock_nodes_collator = mock.MagicMock()
         self.mock_enricher = mock.MagicMock()
@@ -34,7 +34,7 @@ class MyTestCase(TestCase):
         mock_file_open.assert_called_once_with("path/to/x.py", "r")
         self.mock_nodes_collator.collate.assert_called_once_with(code="import colorama", path="path/to/x.py")
         self.mock_enricher.convert.assert_called_once_with(mock_import_node)
-        self.assertEqual({"//third_party/python:colorama"}, deps)
+        self.assertEqual({PlzTarget("//third_party/python:colorama")}, deps)
 
         return
 
@@ -65,7 +65,7 @@ class MyTestCase(TestCase):
         self.mock_nodes_collator.collate.assert_called_once_with(code="import custom.module", path="path/to/y.py")
         self.mock_enricher.convert.assert_called_once_with(mock_import_node)
         mock_get_whatinputs.assert_called_once()
-        self.assertEqual({"//custom:target"}, deps)
+        self.assertEqual({PlzTarget("//custom:target")}, deps)
 
         return
 
@@ -99,7 +99,7 @@ class MyTestCase(TestCase):
         )
         self.mock_enricher.convert.assert_called_once_with(mock_import_node)
         mock_get_whatinputs.assert_called_once()
-        self.assertEqual({"//custom:target"}, deps)
+        self.assertEqual({PlzTarget("//custom:target")}, deps)
 
         return
 

--- a/domain/targets/plz_target.py
+++ b/domain/targets/plz_target.py
@@ -2,8 +2,8 @@ import re
 
 
 class PlzTarget:
-    __absolute_target_path_pattern__ = re.compile(r"^//(.*):(\w+)$")
-    __simple_absolute_target_path_pattern__ = re.compile("^//(.+)$")
+    __absolute_target_path_pattern__ = re.compile(r"^//([\w/]*):(\w+)$")
+    __simple_absolute_target_path_pattern__ = re.compile(r"^//([\w/]+)$")
     __relative_target_path_pattern__ = re.compile(r"^:(\w+)")
 
     def __init__(self, target: str):
@@ -32,7 +32,7 @@ class PlzTarget:
             self.target_name: str = relative_target_match.group(1)
 
         else:
-            raise ValueError(f"{target} does not match the format of a canonical BUILD target path")
+            raise ValueError(f"{target} does not match the format of a BUILD target path")
 
     def __eq__(self, other: "PlzTarget") -> bool:
         return self.canonicalise() == other.canonicalise()

--- a/domain/targets/plz_target.py
+++ b/domain/targets/plz_target.py
@@ -2,9 +2,9 @@ import re
 
 
 class PlzTarget:
-    __absolute_target_path_pattern__ = re.compile(r"^//([\w/]*):(\w+)$")
-    __simple_absolute_target_path_pattern__ = re.compile(r"^//([\w/]+)$")
-    __relative_target_path_pattern__ = re.compile(r"^:(\w+)")
+    __absolute_target_path_pattern__ = re.compile(r"^//([\w/\-]*):(\w+)$")
+    __simple_absolute_target_path_pattern__ = re.compile(r"^//([\w/\-]+)$")
+    __relative_target_path_pattern__ = re.compile(r"^:([\w\-]+)")
 
     def __init__(self, target: str):
         absolute_target_match = re.match(self.__absolute_target_path_pattern__, target)

--- a/domain/targets/plz_target.py
+++ b/domain/targets/plz_target.py
@@ -2,7 +2,7 @@ import re
 
 
 class PlzTarget:
-    __absolute_target_path_pattern__ = re.compile(r"^//(.*):(\w*)$")
+    __absolute_target_path_pattern__ = re.compile(r"^//(.*):(\w+)$")
     __simple_absolute_target_path_pattern__ = re.compile("^//(.+)$")
     __relative_target_path_pattern__ = re.compile(r"^:(\w+)")
 

--- a/domain/targets/plz_target.py
+++ b/domain/targets/plz_target.py
@@ -2,11 +2,12 @@ import re
 
 
 class PlzTarget:
-    __absolute_target_path_pattern__ = re.compile("^//(.*):([a-zA-Z0-9_]*)$")
+    __absolute_target_path_pattern__ = re.compile(r"^//(.*):(\w*)$")
     __simple_absolute_target_path_pattern__ = re.compile("^//(.+)$")
+    __relative_target_path_pattern__ = re.compile(r"^:(\w+)")
 
-    def __init__(self, canonical_build_target_path: str):
-        absolute_target_match = re.match(self.__absolute_target_path_pattern__, canonical_build_target_path)
+    def __init__(self, target: str):
+        absolute_target_match = re.match(self.__absolute_target_path_pattern__, target)
         if absolute_target_match is not None:
             self.build_pkg_dir: str = absolute_target_match.group(1)
             self.target_name: str = (
@@ -18,17 +19,26 @@ class PlzTarget:
 
         simple_absolute_target_match = re.match(
             self.__simple_absolute_target_path_pattern__,
-            canonical_build_target_path,
+            target,
         )
         if simple_absolute_target_match is not None:
             self.build_pkg_dir: str = simple_absolute_target_match.group(1)
             self.target_name: str = self.build_pkg_dir.split("/")[-1]
             return
 
+        relative_target_match = re.match(self.__relative_target_path_pattern__, target)
+        if relative_target_match is not None:
+            self.build_pkg_dir: str = ""
+            self.target_name: str = relative_target_match.group(1)
+
         else:
-            raise ValueError(
-                f"{canonical_build_target_path} does not match the format of a canonical BUILD target path"
-            )
+            raise ValueError(f"{target} does not match the format of a canonical BUILD target path")
+
+    def __eq__(self, other: "PlzTarget") -> bool:
+        return self.canonicalise() == other.canonicalise()
+
+    def __hash__(self):
+        return hash(self.canonicalise())
 
     def __str__(self):
         return self.simplify()

--- a/domain/targets/plz_target_test.py
+++ b/domain/targets/plz_target_test.py
@@ -31,6 +31,12 @@ class TestPlzTarget(TestCase):
         self.assertEqual("to", plz_target.target_name)
         return
 
+    def test_with_relative_target_path_pattern(self):
+        plz_target = PlzTarget("//:target")
+        self.assertEqual("", plz_target.build_pkg_dir)
+        self.assertEqual("target", plz_target.target_name)
+        return
+
     def test_with_tag(self):
         plz_target = PlzTarget("//path/to:target")
         self.assertEqual(

--- a/domain/targets/plz_target_test.py
+++ b/domain/targets/plz_target_test.py
@@ -7,7 +7,7 @@ class TestPlzTarget(TestCase):
     def test_invalid_target_pattern_raises_err(self):
         self.assertRaisesRegex(
             ValueError,
-            "potato does not match the format of a canonical BUILD target path",
+            "potato does not match the format of a BUILD target path",
             PlzTarget,
             "potato",
         )

--- a/domain/targets/python_target.py
+++ b/domain/targets/python_target.py
@@ -19,7 +19,7 @@ class PythonTargetTypes(Enum):
 
 
 class Target:
-    readable_attributes = frozenset({"srcs", "deps"})
+    readable_attributes = frozenset({"srcs", "deps", "name"})
     modifiable_attributes = frozenset({"deps"})
 
     def __init__(self, *, rule_name: str, **kwargs):
@@ -57,7 +57,7 @@ class Target:
     def __getitem__(self, item: str) -> Optional[set[str]]:
         if item not in self.readable_attributes:
             return None
-        return getattr(self.kwargs, item, None)
+        return self.kwargs.get(item)
 
     def __setitem__(self, key: str, value: set[str]) -> None:
         if self.kwargs[key] is None:

--- a/main.py
+++ b/main.py
@@ -1,70 +1,72 @@
 import os
+import logging
 from argparse import ArgumentParser
-from logging import INFO
 
-from adapters.custom_arg_types import existing_file_arg_type
+from adapters.custom_arg_types import existing_dir_arg_type
 from adapters.plz_query import (
+    get_build_file_names,
+    get_third_party_module_targets,
     get_python_moduledir,
     get_reporoot,
-    get_third_party_module_targets,
 )
-from common.logger.logger import setup_logger
+from domain.build_pkgs.build_pkg import BUILDPkg
+from domain.imports.enricher import ToEnrichedImports
 from domain.imports.nodes_collator import NodesCollator
 from domain.imports.stdlib_modules import get_stdlib_module_names
-from domain.targets.resolver import Resolver
-
-LOGGER = setup_logger(__file__, INFO)
+from domain.targets.plz.dependency_resolver import DependencyResolver
 
 
-def run(path_to_pyfile: str):
+def run(build_pkg_dir_paths: list[str]):
+    """
+
+    :param build_pkg_dir_paths: Relative to reporoot
+    :return:
+    """
+
     # Get 3rd Party libs and builtins
     third_party_modules_targets: set[str] = set(get_third_party_module_targets())
     std_lib_modules: set[str] = get_stdlib_module_names()
+    build_file_names: list[str] = get_build_file_names()
 
-    # Read pyfile.
-    with open(path_to_pyfile) as f:
-        code = f.read()
+    build_pkg_dirs: list[BUILDPkg] = []
+    for build_pkg_dir_path in build_pkg_dir_paths:
+        build_pkg_dirs.append(BUILDPkg(build_pkg_dir_path, set(build_file_names)))
 
-    # Get import nodes from Python file
-    collator = NodesCollator()
-    reporoot: str = get_reporoot()
-
-    # Convert import nodes to plz targets
-    plz_target_resolver = Resolver(
-        reporoot,
-        get_python_moduledir(),
-        std_lib_modules,
-        third_party_modules_targets,
-    )
-    plz_target_resolver.resolve(collator.collate(code=code, path=path_to_pyfile))
-
-    for source in plz_target_resolver.custom_module_sources_without_targets:
-        LOGGER.error(f"Import does not have a plz target: {source}")
-
-    LOGGER.info(
-        targets_as_deps(
-            list(plz_target_resolver.third_party_module_imports) + list(plz_target_resolver.custom_module_targets)
-        )
+    python_moduledir = get_python_moduledir()
+    dependency_resolver = DependencyResolver(
+        python_moduledir=python_moduledir,
+        enricher=ToEnrichedImports(get_reporoot(), python_moduledir),
+        std_lib_modules=std_lib_modules,
+        available_third_party_module_targets=third_party_modules_targets,
+        nodes_collator=NodesCollator(),
     )
 
+    for build_pkg_dir in build_pkg_dirs:
+        build_pkg_dir.resolve_deps_for_targets(dependency_resolver.resolve_deps_for_srcs)
+        print(build_pkg_dir)
+        # TODO: trial by fire... RUN THE DAMN THING
     return
 
 
-def targets_as_deps(targets):
-    return "deps = {}".format(targets).replace("'", '"')
-
-
 if __name__ == "__main__":
+    from common.logger.logger import setup_logger
+
     parser = ArgumentParser()
 
     parser.add_argument(
-        "pyfile",
-        type=existing_file_arg_type,
-        help="Path to Python file from which to calculate plz deps.",
+        "build_pkg_dir",
+        type=existing_dir_arg_type,
+        nargs="+",
+        help="BUILD package directories (relative to reporoot)",
     )
+    parser.add_argument("--verbose", "-v", action="count", default=0)
 
     args = parser.parse_args()
+    print(log_level := max(0, logging.WARNING - (10 * args.verbose)))
+    os.environ["PYLLEMI_LOG_LEVEL"] = str(log_level)
 
-    LOGGER.info(f"pyfile: {args.pyfile}; cwd: {os.getcwd()}")
+    LOGGER = setup_logger(__file__)
 
-    run(args.pyfile)
+    build_pkg_dirs_arg = args.build_pkg_dir
+    LOGGER.info(f"resolving imports for {', '.join(build_pkg_dirs_arg)}; cwd: {os.getcwd()}")
+    run(build_pkg_dirs_arg)

--- a/main.py
+++ b/main.py
@@ -43,8 +43,8 @@ def run(build_pkg_dir_paths: list[str]):
 
     for build_pkg_dir in build_pkg_dirs:
         build_pkg_dir.resolve_deps_for_targets(dependency_resolver.resolve_deps_for_srcs)
-        print(build_pkg_dir)
-        # TODO: trial by fire... RUN THE DAMN THING
+        LOGGER.info(build_pkg_dir)
+        # build_pkg_dir.write_to_build_file()
     return
 
 
@@ -62,11 +62,10 @@ if __name__ == "__main__":
     parser.add_argument("--verbose", "-v", action="count", default=0)
 
     args = parser.parse_args()
-    print(log_level := max(0, logging.WARNING - (10 * args.verbose)))
-    os.environ["PYLLEMI_LOG_LEVEL"] = str(log_level)
+    os.environ["PYLLEMI_LOG_LEVEL"] = str(max(0, logging.WARNING - (10 * args.verbose)))
 
     LOGGER = setup_logger(__file__)
 
     build_pkg_dirs_arg = args.build_pkg_dir
-    LOGGER.info(f"resolving imports for {', '.join(build_pkg_dirs_arg)}; cwd: {os.getcwd()}")
+    LOGGER.debug(f"resolving imports for {', '.join(build_pkg_dirs_arg)}; cwd: {os.getcwd()}")
     run(build_pkg_dirs_arg)

--- a/utils/mock_python_library_test_case.py
+++ b/utils/mock_python_library_test_case.py
@@ -29,7 +29,7 @@ class MockPythonLibraryTestCase(TestCase):
             f.write(f"# TEST: {self.test_dir}")
 
         with open(self.subpackage_build_file, "w") as f:
-            f.write("""python_test(name="test_subpackage", srcs=["test_module_0.py", "test_module_1.py"])""")
+            f.write("""python_test(name="test_subpackage", srcs=["test_module_1.py"])""")
 
         with open(self.package_module, "w") as f:
             f.write("x = 5")


### PR DESCRIPTION
* Create new main.py
* Add ability to input multiple directories
* Create PYLLEMI_LOG_LEVEL env var to allow for user-defined log level globally
* Make PlzTarget hashable
* Add "name" to the set of readable attributes of a Target
* Correct BUILD file srcs (detected by Pyllemi!)

### Manual Test Plan:
- [x] Input single BUILD pkg dir with pre-existing Python BUILD targets.
- [x] Input multiple BUILD pkg dirs with pre-existing Python BUILD targets.
- [x] Input single dir path _without_ pre-existing Python BUILD targets, but containing 1 or more Python src files. Expect a new BUILD file to be written in that directory.
- [x] Input single dir path _without_ pre-existing Python BUILD targets, but containing 1 or more Python test src files (`*_test.py`). Expect a new BUILD file to be written in that directory.
- [x] Input non-existent BUILD pkg dir; expect an error saying the path does not exist.