### PR TITLE
Add ability to have multiple config files

### DIFF
--- a/adapters/os/BUILD
+++ b/adapters/os/BUILD
@@ -8,7 +8,7 @@ python_library(
     ),
     deps = [
         "//common/logger",
-        "//domain/targets",
+        "//domain/plz/rule",
     ],
 )
 
@@ -17,7 +17,7 @@ python_test(
     srcs = glob(["*_test.py"]),
     deps = [
         ":os",
-        "//domain/targets",
+        "//domain/plz/rule",
         "//utils",
     ],
 )

--- a/config/config.py
+++ b/config/config.py
@@ -7,6 +7,23 @@ import jsonschema
 from config.common import LOGGER
 from config.schema import SCHEMA
 
+CONFIG_FILE_NAME = ".pyllemi.json"
+
+
+def find_files_in_dir_hierarchy(path: str) -> list[str]:
+    if not os.path.isdir(path):
+        return []
+
+    config_file_paths: list[str] = []
+    for subdir in os.path.join(".", path).split(os.path.sep):
+        if not os.path.isfile(config_file_path := os.path.join(subdir, CONFIG_FILE_NAME)):
+            continue
+        config_file_paths.append(config_file_path)
+
+    # The most deeply nested config file path first -- return in order of descending precedence.
+    config_file_paths.reverse()
+    return config_file_paths
+
 
 def unmarshal(path: str) -> dict[str, Any]:
     if not os.path.isfile(path):

--- a/config/merge.py
+++ b/config/merge.py
@@ -1,0 +1,47 @@
+from typing import TypeVar
+
+from config.schema import (
+    KNOWN_DEPENDENCIES_KEY,
+    KNOWN_NAMESPACES_KEY,
+    USE_GLOBS_AS_SRCS_KEY,
+)
+from domain.plz.target.target import Target
+
+MARSHALLED_CONFIG_VALUE_TYPE = TypeVar("MARSHALLED_CONFIG_VALUE_TYPE", bool, list[Target], Target)
+MARSHALLED_CONFIG_TYPE = dict[str, MARSHALLED_CONFIG_VALUE_TYPE]
+
+
+def merge(configs: list[MARSHALLED_CONFIG_TYPE]) -> MARSHALLED_CONFIG_TYPE:
+    """
+
+    :param configs: in descending order of precedence
+    :return:
+    """
+
+    merged_use_globs_as_srcs = _merge_bool_property(USE_GLOBS_AS_SRCS_KEY, configs)
+    merged_known_dependencies = _merge_dict_property(
+        list(map(lambda x: getattr(x, KNOWN_DEPENDENCIES_KEY, {}), configs))
+    )
+    merged_known_namespaces = _merge_dict_property(list(map(lambda x: getattr(x, KNOWN_NAMESPACES_KEY, {}), configs)))
+    return {
+        USE_GLOBS_AS_SRCS_KEY: merged_use_globs_as_srcs,
+        KNOWN_DEPENDENCIES_KEY: merged_known_dependencies,
+        KNOWN_NAMESPACES_KEY: merged_known_namespaces,
+    }
+
+
+def _merge_bool_property(key: str, configs: list[MARSHALLED_CONFIG_TYPE], default: bool = False) -> bool:
+    for config in configs:
+        if (value := config.get(key, None)) is not None:
+            return value
+    return default
+
+
+def _merge_dict_property(configs: list[MARSHALLED_CONFIG_VALUE_TYPE]) -> MARSHALLED_CONFIG_TYPE:
+    merged_property = {}
+    for config in reversed(configs):
+        if not bool(config):
+            # If this config is empty.
+            continue
+        merged_property |= config
+    return merged_property

--- a/config/merge_test.py
+++ b/config/merge_test.py
@@ -1,0 +1,85 @@
+from collections import namedtuple
+from unittest import TestCase
+
+from config.merge import _merge_bool_property, _merge_dict_property
+from config.schema import USE_GLOBS_AS_SRCS_KEY, KNOWN_NAMESPACES_KEY, KNOWN_DEPENDENCIES_KEY
+
+
+class TestMerge(TestCase):
+    def test__merge_bool_property(self):
+        with self.subTest("overrides parent values"):
+            self.assertFalse(
+                _merge_bool_property(
+                    USE_GLOBS_AS_SRCS_KEY,
+                    [
+                        {USE_GLOBS_AS_SRCS_KEY: False, KNOWN_NAMESPACES_KEY: {}, KNOWN_DEPENDENCIES_KEY: {}},
+                        {USE_GLOBS_AS_SRCS_KEY: True, KNOWN_NAMESPACES_KEY: {"x.y": "//x:y"}},
+                        {USE_GLOBS_AS_SRCS_KEY: False, KNOWN_DEPENDENCIES_KEY: {"x.y": "//a/b:c"}},
+                        {USE_GLOBS_AS_SRCS_KEY: False},
+                    ],
+                    default=False,
+                ),
+            )
+
+        with self.subTest("inherits true value"):
+            self.assertTrue(
+                _merge_bool_property(
+                    USE_GLOBS_AS_SRCS_KEY,
+                    [
+                        {KNOWN_NAMESPACES_KEY: {}, KNOWN_DEPENDENCIES_KEY: {}},
+                        {USE_GLOBS_AS_SRCS_KEY: True, KNOWN_NAMESPACES_KEY: {"x.y": "//x:y"}},
+                        {USE_GLOBS_AS_SRCS_KEY: False, KNOWN_DEPENDENCIES_KEY: {"x.y": "//a/b:c"}},
+                        {USE_GLOBS_AS_SRCS_KEY: True},
+                    ],
+                    default=False,
+                ),
+            )
+
+        with self.subTest("inherits false value"):
+            self.assertFalse(
+                _merge_bool_property(
+                    USE_GLOBS_AS_SRCS_KEY,
+                    [
+                        {KNOWN_NAMESPACES_KEY: {}, KNOWN_DEPENDENCIES_KEY: {}},
+                        {USE_GLOBS_AS_SRCS_KEY: False, KNOWN_NAMESPACES_KEY: {"x.y": "//x:y"}},
+                        {USE_GLOBS_AS_SRCS_KEY: True, KNOWN_DEPENDENCIES_KEY: {"x.y": "//a/b:c"}},
+                        {USE_GLOBS_AS_SRCS_KEY: True},
+                    ],
+                    default=False,
+                ),
+            )
+
+        return
+
+    def test__merge_dict_property_with(self):
+        SubTest = namedtuple("SubTest", ["name", "key", "input", "expected_output"])
+        testcases = [
+            SubTest(
+                name="overrides parent config",
+                key=KNOWN_NAMESPACES_KEY,
+                input=[
+                    {"x.y.z": "//x/y:z1", "a.b.c": ["//a/b:c"]},
+                    {"x.y.z": "//x/y:z2", "a.b.c": ["//blah"]},
+                    {"x.y.z": "//x/y:z3"},
+                ],
+                expected_output={"x.y.z": "//x/y:z1", "a.b.c": ["//a/b:c"]},
+            ),
+            SubTest(
+                name="inherits parent config",
+                key=KNOWN_NAMESPACES_KEY,
+                input=[
+                    {"x.y.z": "//x/y:z"},
+                    {"x.y.z": "//x/y:z"},
+                    {"x.y.z": "//x/y:z", "a.b.c": ["//a/b:c"]},
+                ],
+                expected_output={"x.y.z": "//x/y:z", "a.b.c": ["//a/b:c"]},
+            ),
+        ]
+
+        for testcase in testcases:
+            with self.subTest(testcase.name):
+                self.assertEqual(
+                    testcase.expected_output,
+                    _merge_dict_property(testcase.input),
+                )
+        return

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,9 +1,9 @@
 from typing import Union
 
 
-KNOWN_DEPENDENCIES_KEY = "knownDependencies"
-KNOWN_NAMESPACES_KEY = "knownNamespaces"
-USE_GLOBS_AS_SRCS_KEY = "useGlobAsSrcs"
+KNOWN_DEPENDENCIES_KEY: str = "knownDependencies"
+KNOWN_NAMESPACES_KEY: str = "knownNamespaces"
+USE_GLOBS_AS_SRCS_KEY: str = "useGlobAsSrcs"
 
 UNMARSHALLED_CONFIG_TYPE = dict[str, Union[bool, list[dict[str, str]]]]
 

--- a/domain/build_pkgs/BUILD
+++ b/domain/build_pkgs/BUILD
@@ -10,7 +10,9 @@ python_library(
         "//adapters/os",
         "//common/logger",
         "//domain/build_files",
-        "//domain/targets",
+        "//domain/plz/rule",
+        "//domain/plz/target",
+        "//service/ast/converters",
     ],
 )
 
@@ -19,7 +21,8 @@ python_test(
     srcs = glob(["*_test.py"]),
     deps = [
         ":build_pkgs",
-        "//domain/targets",
+        "//domain/plz/rule",
+        "//domain/plz/target",
         "//utils",
     ],
 )

--- a/domain/build_pkgs/build_pkg.py
+++ b/domain/build_pkgs/build_pkg.py
@@ -54,6 +54,9 @@ class BUILDPkg:
             self._infer_targets_and_add_to_build_file()
             if self._uncommitted_changes:
                 self.write_to_build_file()
+            else:
+                self._logger.warning(f"No BUILD file or Python modules found in {self._dir_path}")
+                return
 
         # There should now already be a BUILD file within this directory; read it and
         # load existing Python target declarations into domain representations.

--- a/domain/build_pkgs/build_pkg_test.py
+++ b/domain/build_pkgs/build_pkg_test.py
@@ -1,4 +1,5 @@
 import ast
+import os
 from unittest import mock
 
 from domain.build_pkgs.build_pkg import BUILDPkg
@@ -102,6 +103,19 @@ class TestBuildPkgWithNewBuildPkg(MockPythonLibraryWithNewBuildPkgTestCase):
         mock_build_file_instance.add_new_target.assert_called_once_with(mock_python_lib)
         mock_file_open.return_value.write.assert_called_once_with(mock_dumped_ast)
 
+        return
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    def test_no_build_file_nor_python_modules_in_dir(
+        self,
+        mock_file_open: mock.MagicMock,
+    ):
+        os.makedirs(test_dir := os.path.join(self.test_dir, "no_build_file_nor_py_srcs"))
+        self.dirs_to_delete = [test_dir] + self.dirs_to_delete
+        build_pkg = BUILDPkg(test_dir, frozenset({"BUILD"}), config={"useGlobAsSrcs": True})
+        self.assertEqual(0, mock_file_open.return_value.write.call_count)
+        self.assertFalse(build_pkg.has_uncommitted_changes())
+        self.assertFalse(build_pkg.has_been_modified)
         return
 
 

--- a/domain/plz/rule/BUILD
+++ b/domain/plz/rule/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility=["//domain/...", "//service/..."])
+package(default_visibility=["//domain/...", "//service/...", "//adapters/..."])
 
 python_library(
     name = "rule",


### PR DESCRIPTION
* Add function to find all config files in dir hierarchy
* Add function to merge config
* Compute merged config separately for each input BUILD pkg dir
* Bugfix: log warning when input dir has no BUILD file nor any potential Python sources; this was raising an error previously
* Add unit test for bugfix
* Run Pyllemi on various existing packages to fix imports

Closes #38