### PR TITLE
Bugfix: Ensure custom module imports work properly

### DIFF
--- a/service/ast/converters/to_enriched_imports.py
+++ b/service/ast/converters/to_enriched_imports.py
@@ -86,9 +86,6 @@ class ToEnrichedImports:
                 imports.append(self._resolve_import_from_import_path_candidate(f"{node.module}.{name.name}"))
                 continue
 
-            if module_only_import.type == enriched_import.Type.UNKNOWN:
-                imports.append(self._resolve_import_from_import_path_candidate(f"{node.module}.{name.name}"))
-
             if module_only_import.type != enriched_import.Type.PACKAGE:
                 imports.append(module_only_import)
                 continue

--- a/service/dependency/resolver.py
+++ b/service/dependency/resolver.py
@@ -109,9 +109,7 @@ class DependencyResolver:
             # Batch whatinputs calls for performance gains.
             self._whatinputs_inputs_for_this_target |= set(whatinputs_input)
 
-        if (
-            namespace_pkg := trie.longest_existing_path_in_trie(self.namespace_pkg_lookup, import_.import_)
-        ) != "":
+        if (namespace_pkg := trie.longest_existing_path_in_trie(self.namespace_pkg_lookup, import_.import_)) != "":
             self._logger.debug(f"Found import of a known namespace package: {namespace_pkg}")
             return self.namespace_pkg_to_target[namespace_pkg]
 


### PR DESCRIPTION
There was a stray `if` block which was erroneously classifying imports. This is now been removed.